### PR TITLE
Fix TYPO3 v10 requirements in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
         "typo3-ter/hh-video-extender": "self.version"
     },
     "require": {
-        "typo3/cms-core": "^9.5.0 || ^10.4.99",
-        "typo3/cms-fluid": "^9.5.0 || ^10.4.99",
-        "typo3/cms-frontend": "^9.5.0 || ^10.4.99",
-        "typo3/cms-fluid-styled-content": "^9.5.0 || ^10.4.99"
+        "typo3/cms-core": "^9.5.0 || ^10.4.0",
+        "typo3/cms-fluid": "^9.5.0 || ^10.4.0",
+        "typo3/cms-frontend": "^9.5.0 || ^10.4.0",
+        "typo3/cms-fluid-styled-content": "^9.5.0 || ^10.4.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Else, the installation is not possible:
```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for hauerheinrich/hh-video-extender ^0.1.62 -> satisfiable by hauerheinrich/hh-video-extender[0.1.62].
    - hauerheinrich/hh-video-extender 0.1.62 requires typo3/cms-core ^9.5.0 || ^10.4.99 -> satisfiable by typo3/cms-core[10.4.x-dev, 9.5.x-dev, v9.5.0, v9.5.1, v9.5.10, v9.5.11, v9.5.12, v9.5.13, v9.5.14, v9.5.15, v9.5.16, v9.5.17, v9.5.18, v9.5.19, v9.5.2, v9.5.20, v9.5.21, v9.5.3, v9.5.4, v9.5.5, v9.5.6, v9.5.7, v9.5.8, v9.5.9] but these conflict with your requirements or minimum-stability.
```